### PR TITLE
PHP opcache update

### DIFF
--- a/hiera/common-osrelease-7.yaml
+++ b/hiera/common-osrelease-7.yaml
@@ -57,8 +57,3 @@ site_profile::web::php_packages:
   - php-soap
   - php-xml
   - php-xmlrpc
-
-# PHP Opcache Configuration.
-site_profile::web::php_opcache_ini:
-  opcache.enable: 1
-  opcache.memory_consumption: 96

--- a/hiera/common.yaml
+++ b/hiera/common.yaml
@@ -122,6 +122,14 @@ site_profile::web::enable_php_memcached: TRUE
 site_profile::web::php_memcache_ini:
   memcache.hash_strategy: 'consistent'
 
+# PHP Opcache Configuration.
+site_profile::web::php_opcache_ini:
+  opcache.enable: 1
+  opcache.memory_consumption: 96
+
+# This matches the '10-' prefix used in the RPM for the PHP opcache ini file.
+site_profile::web::php_opcache_prefix: '10'
+
 #############################################
 # Memcached Settings.
 

--- a/site/site_profile/manifests/web.pp
+++ b/site/site_profile/manifests/web.pp
@@ -39,6 +39,7 @@ class site_profile::web {
     /opcache/: {
       php::module::ini { 'opcache':
         pkgname  => $opcache_pkg_name,
+        prefix   => hiera('site_profile::web::php_opcache_prefix', '10'),
         settings => hiera_hash('site_profile::web::php_opcache_ini', {}),
         zend     => true,
       }


### PR DESCRIPTION
Move PHP opcache hiera config into common.yaml so it is available to EL6.

Update opcache INI config to use the prefix '10-' used by the opcache RPM.
