### PR TITLE
Default to CentOS 7 VM, Disable SELinux on Dev VM

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -3,7 +3,7 @@ forge 'forge.puppetlabs.com'
 
 # Install modules from the Forge
 mod 'crayfishx/firewalld', '1.0.0'
-mod 'jfryman/selinux', '0.2.3'
+mod 'jfryman/selinux', '0.2.5'
 mod 'puppetlabs/apache', '1.5.0'
 mod 'puppetlabs/concat', '1.2.3'
 mod 'puppetlabs/denyhosts', '0.1.0'

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -38,13 +38,13 @@ Vagrant.configure('2') do |config|
   if defined? $box
     config.vm.box = $box
   else
-    config.vm.box = "tag1/centos6-50GB-vbguest"
+    config.vm.box = "tag1/centos7-50GB-vbguest"
   end
 
   if defined? $box_url
     config.vm.box_url = $box_url
   else
-    config.vm.box_url = "http://pkg.tag1consulting.com/vagrant-boxes/centos6-50GB-vbguest/metadata.json"
+    config.vm.box_url = "http://pkg.tag1consulting.com/vagrant-boxes/centos7-50GB-vbguest/metadata.json"
   end
 
   # Enable ssh agent forwarding

--- a/Vagrantfile.local.example
+++ b/Vagrantfile.local.example
@@ -14,8 +14,8 @@ $vms = {
   }
 
 # Box source
-$box = "tag1/centos6-50GB-vbguest"
-$box_url = "http://pkg.tag1consulting.com/vagrant-boxes/centos6-50GB-vbguest/metadata.json"
+$box = "tag1/centos7-50GB-vbguest"
+$box_url = "http://pkg.tag1consulting.com/vagrant-boxes/centos7-50GB-vbguest/metadata.json"
 
 # Provide list of source mounts. The type defaults to virtualbox, but you could
 # also use nfs (on Mac/Linux) or the rsync type.

--- a/hiera/common.yaml
+++ b/hiera/common.yaml
@@ -5,6 +5,7 @@
 # Class definitions.
 classes:
  - site_profile::base
+ - selinux
 
 #############################################
 # Global enable/disable flags.
@@ -215,3 +216,8 @@ site_profile::base::sudo_conf:
 # Packages required for testing.
 site_profile::web_test::test_packages:
   - perl-Chart
+
+#################################################
+# SELinux configuration.
+# Enable selinux by default.
+selinux::mode: 'enforcing'

--- a/hiera/hosts/vagrant-multi1.tag1consulting.com.yaml
+++ b/hiera/hosts/vagrant-multi1.tag1consulting.com.yaml
@@ -46,3 +46,7 @@ mysql::server::grants:
     privileges: ['ALL']
     table: 'vagrant.*'
 
+#################################################
+# SELinux configuration.
+# Disable selinux on Dev VM.
+selinux::mode: 'disabled'

--- a/scripts/Vagrantfile.default
+++ b/scripts/Vagrantfile.default
@@ -14,8 +14,8 @@ $vms = {
   }
 
 # Box source
-$box = "tag1/centos6-50GB-vbguest"
-$box_url = "http://pkg.tag1consulting.com/vagrant-boxes/centos6-50GB-vbguest/metadata.json"
+$box = "tag1/centos7-50GB-vbguest"
+$box_url = "http://pkg.tag1consulting.com/vagrant-boxes/centos7-50GB-vbguest/metadata.json"
 
 # Provide list of source mounts. The type defaults to virtualbox, but you could
 # also use nfs (on Mac/Linux) or the rsync type.


### PR DESCRIPTION
This updates the default VM to use our CentOS 7 box.
Also enables the selinux Puppet module by default and disables selinux on the "dev VM" (vagrant-multi1.tag1consulting.com) by default.
