### PR TITLE
Xdebug changes

### DIFF
--- a/hiera/common.yaml
+++ b/hiera/common.yaml
@@ -108,7 +108,6 @@ site_profile::web::php_packages:
   - php56u-pdo
   - php56u-pear
   - php56u-soap
-  - php56u-xdebug
   - php56u-xml
   - php56u-xmlrpc
 

--- a/hiera/types/multi.yaml
+++ b/hiera/types/multi.yaml
@@ -4,4 +4,5 @@
 # Class definitions.
 classes:
   - site_profile::db
+  - site_profile::phpxdebug
   - site_profile::web

--- a/site/site_profile/manifests/phpxdebug.pp
+++ b/site/site_profile/manifests/phpxdebug.pp
@@ -13,6 +13,7 @@ class site_profile::phpxdebug (
     prefix   => $xdebug_ini_prefix,
     settings => $xdebug_settings,
     zend     => true,
+    notify   => Service['httpd'],
   }
 
 }

--- a/site/site_profile/manifests/phpxdebug.pp
+++ b/site/site_profile/manifests/phpxdebug.pp
@@ -1,0 +1,18 @@
+class site_profile::phpxdebug (
+  $xdebug_package_name = 'php56u-pecl-xdebug',
+  $xdebug_ini_prefix   = '15',
+  $xdebug_settings     = { 'xdebug.remote_enable' => 1, 'xdebug.remote_connect_back' => 1, },
+) {
+
+  package { $xdebug_package_name:
+    ensure => installed,
+  }
+
+  php::module::ini { 'xdebug':
+    pkgname  => $xdebug_package_name,
+    prefix   => $xdebug_ini_prefix,
+    settings => $xdebug_settings,
+    zend     => true,
+  }
+
+}


### PR DESCRIPTION
Pulls php xdebug package out of default PHP install list into a separate profile class which is now enabled by default for `-multi` hosts.

Enables php xdebug remote access by default on those hosts.
