### PR TITLE
Add redis support

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -2,6 +2,7 @@
 forge 'forge.puppetlabs.com'
 
 # Install modules from the Forge
+mod 'arioch/redis', '1.2.1'
 mod 'crayfishx/firewalld', '1.0.0'
 mod 'jfryman/selinux', '0.2.5'
 mod 'puppetlabs/apache', '1.5.0'

--- a/hiera/common.yaml
+++ b/hiera/common.yaml
@@ -248,3 +248,7 @@ selinux::mode: 'enforcing'
 # Vhost Directory Settings
 apache::purge_vhost_dir: false
 apache::vhost_dir: '/etc/httpd/vhost.d'
+
+#################################################
+#Redis
+redis::bind: '127.0.0.1'


### PR DESCRIPTION
Add initial redis support, can be enabled with default config on a node by adding the redis class. 
