### PR TITLE
Add xhgui

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -9,9 +9,11 @@ mod 'puppetlabs/apache', '1.8.1'
 mod 'puppetlabs/concat', '2.2.0'
 mod 'puppetlabs/denyhosts', '0.1.0'
 mod 'puppetlabs/firewall', '1.8.1'
+mod 'puppetlabs/git', '0.5.0'
 mod 'puppetlabs/inifile', '1.5.0'
 mod 'puppetlabs/java', '1.6.0'
 mod 'puppetlabs/mysql', '3.8.0'
+mod 'puppetlabs/mongodb', '0.14.0'
 mod 'puppetlabs/stdlib', '4.12.0'
 mod 'puppetlabs/vcsrepo', '1.3.2'
 mod 'saz/sudo', '3.1.0'
@@ -20,9 +22,15 @@ mod 'tag1/yumrepos', '0.9.1'
 mod 'thias/php', '1.2.0'
 mod 'treydock/yum_cron', '2.0.0'
 mod 'torrancew/account', '0.1.0'
+mod 'tPl0ch/composer', '1.3.7'
 
 # This module installs policycoreutils-python which conflicts with the selinux module.
 # Temporarily using a fork until https://github.com/RPDiep/puppet-memcached/issues/7 is sorted.
 mod 'memcached',
   :git => 'git://github.com/jeffsheltren/puppet-memcached.git',
   :ref => 'no-policycoreutils'
+
+# Not on the forge yet
+mod 'xhgui',
+  :git    => 'https://github.com/gchaix/puppet-xhgui.git',
+  :branch => 'master'

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -49,6 +49,18 @@ Vagrant.configure('2') do |config|
   end
   config.vbguest.auto_update = $vbguest_auto_update
 
+  # Configure additional aliases for the hostsupdater plugin.
+  # These can be defined in Vagrantfile.local
+  if Vagrant.has_plugin?("vagrant-triggers")
+    if !defined? $host_aliases
+      $host_aliases = [
+        "vagrant-multi1.tag1consulting.com",
+        "vagrant-xhgui.tag1consulting.com"
+        ]
+    end
+    config.hostsupdater.aliases = $host_aliases
+  end
+
   # Temporary workaround for https://github.com/mitchellh/vagrant/issues/7610 (9/1/16)
   config.ssh.insert_key = false
 

--- a/hiera/common.yaml
+++ b/hiera/common.yaml
@@ -39,7 +39,6 @@ allow_virtual_packages: TRUE
 site_profile::base::base_packages:
   - bash-completion
   - dstat
-  - git
   - htop
   - iotop
   - lsof
@@ -49,6 +48,7 @@ site_profile::base::base_packages:
   - strace
   - tcpdump
   - telnet
+  - vim
   - yum-plugin-replace
 
 #############################################

--- a/scripts/fix-xhgui-composer.sh
+++ b/scripts/fix-xhgui-composer.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# We need some devel stuff
+sudo yum install -q -y composer php56u-devel openssl-devel 2>&1 > /dev/null
+
+# Even through it's already installed, we need to install using pecl
+sudo pecl install mongodb 2>&1 > /dev/null
+
+# Temporarily set it to mongodb.so
+# Yes, I know it'll be replaced by the next provision, but this is only to make composer run once
+sudo sed -i.bak -e s/mongo.so/mongodb.so/g /etc/php.d/50-mongo.ini
+
+# Perms are wrong
+if [ ! -d /var/www/xhgui/vendor ];
+  then 
+    sudo mkdir /var/www/xhgui/vendor
+fi
+sudo chown vagrant:vagrant /var/www/xhgui/vendor
+sudo chmod 0777 /var/www/xhgui/cache
+
+# Now composer should run
+cd /var/www/xhgui
+sudo -u vagrant composer install
+
+echo "xhgui is now available at http://vagrant-xhgui.tag1consulting.com" 

--- a/site/site_profile/manifests/phpxhprof.pp
+++ b/site/site_profile/manifests/phpxhprof.pp
@@ -27,4 +27,17 @@ class site_profile::phpxhprof (
   # Create cron jobs if any are specified. To e.g. clean up temp xhprof files.
   create_resources('cron', $xhprof_crons)
 
+  # XHGui needs MongoDB
+  class { '::mongodb::server': }
+  class { '::mongodb::client': }
+
+  # Add XHGui
+  #include composer
+  class { 'xhgui':
+    vhost_name        => 'vagrant-xhgui.tag1consulting.com',
+    sample_size       => '1',
+    php_mongo_package => 'php56u-pecl-mongo',
+    xhprof_package    => $xhprof_package_name,
+  }
+
 }


### PR DESCRIPTION
Not ready for merge!  The composer install needed to run xhgui is broken.  Until it is fixed, run `vagrant ssh -c "/vagrant/scripts/fix-xhgui-composer.sh"`on first boot to enable it.
