### PR TITLE
Add site_selinux module and enable selinux by default

### DIFF
--- a/hiera/common.yaml
+++ b/hiera/common.yaml
@@ -5,7 +5,6 @@
 # Class definitions.
 classes:
  - site_profile::base
- - selinux
 
 #############################################
 # Global enable/disable flags.

--- a/hiera/hosts/vagrant-multi1.tag1consulting.com.yaml
+++ b/hiera/hosts/vagrant-multi1.tag1consulting.com.yaml
@@ -54,8 +54,8 @@ mysql::server::grants:
 
 #################################################
 # SELinux configuration.
-# Disable selinux on Dev VM.
-selinux::mode: 'disabled'
+# Uncomment this to disable SELinux on the Dev VM.
+#selinux::mode: 'disabled'
 
 #################################################
 # PHP configuration.

--- a/site/site_profile/manifests/base.pp
+++ b/site/site_profile/manifests/base.pp
@@ -27,6 +27,9 @@ class site_profile::base {
   $user_accounts = hiera_hash('user_accounts', {} )
   create_resources('account', $user_accounts)
 
+  # SELinux configuration for all hosts.
+  class { 'site_selinux': }
+
   # Base Sudo setup.
   class { 'sudo': }
 

--- a/site/site_profile/manifests/web.pp
+++ b/site/site_profile/manifests/web.pp
@@ -8,6 +8,9 @@ class site_profile::web {
   $firewall_rules = hiera_hash('site_profile::web::firewall_rules', {})
   create_resources(hiera('firewall_provider', 'firewall'), $firewall_rules)
 
+  # SELinux configuration for Drupal sites.
+  class { 'site_selinux::drupal': }
+
   # Setup Apache base class, includes default vhost.
   class  { 'apache': }
   # Setup Vhosts.

--- a/site/site_selinux/files/httpdsolr/httpdsolr.te
+++ b/site/site_selinux/files/httpdsolr/httpdsolr.te
@@ -1,0 +1,15 @@
+module httpdsolr 0.0.2;
+
+require {
+  attribute port_type;
+  class tcp_socket name_connect;
+  type httpd_t;
+  type varnishd_t;
+}
+
+# Define a new port type for solr.
+type solr_port_t, port_type;
+
+# Allow Apache/PHP/Varnish to connect to solr ports.
+allow httpd_t solr_port_t:tcp_socket name_connect;
+allow varnishd_t solr_port_t:tcp_socket name_connect;

--- a/site/site_selinux/files/httpdvarnish/httpdvarnish.te
+++ b/site/site_selinux/files/httpdvarnish/httpdvarnish.te
@@ -1,0 +1,11 @@
+module httpdvarnish 0.0.1;
+
+require {
+  class tcp_socket name_connect;
+  type httpd_t;
+  type varnishd_port_t;
+
+}
+
+# Allow php/apache to connect to varnish to purge/ban cache items.
+allow httpd_t varnishd_port_t:tcp_socket name_connect;

--- a/site/site_selinux/files/newrelic/newrelic.te
+++ b/site/site_selinux/files/newrelic/newrelic.te
@@ -1,0 +1,23 @@
+module newrelic 0.0.9;
+
+require {
+  type var_log_t;
+  type httpd_t;
+  type tmp_t;
+  type var_run_t;
+  type sysctl_net_t;
+  type initrc_t;
+  class file open;
+  class capability2 block_suspend;
+  class sock_file write;
+  class file { read lock write open };
+  class unix_stream_socket connectto;
+}
+
+allow httpd_t self:capability2 block_suspend;
+allow httpd_t var_log_t:file open;
+allow httpd_t tmp_t:sock_file write;
+allow httpd_t var_run_t:file { read lock write open };
+allow httpd_t sysctl_net_t:file { read open };
+allow httpd_t var_run_t:sock_file write;
+allow httpd_t initrc_t:unix_stream_socket connectto;

--- a/site/site_selinux/files/php-systemd/php-systemd.te
+++ b/site/site_selinux/files/php-systemd/php-systemd.te
@@ -1,0 +1,14 @@
+module php-systemd 0.0.6;
+
+require {
+  type httpd_t;
+  attribute port_type;
+  class tcp_socket name_bind;
+  class tcp_socket name_connect;
+}
+
+# Define a new port type for php.
+type php_port_t, port_type;
+
+allow httpd_t php_port_t:tcp_socket name_bind;
+allow httpd_t php_port_t:tcp_socket name_connect;

--- a/site/site_selinux/files/puppetmaster/puppetmaster.te
+++ b/site/site_selinux/files/puppetmaster/puppetmaster.te
@@ -1,0 +1,32 @@
+module puppetmaster 0.4;
+
+# SELinux module for running puppetmaster behind apache/passenger.
+
+require {
+  type puppet_etc_t;
+  type puppet_var_lib_t;
+  type puppet_log_t;
+  type puppet_port_t;
+  type httpd_t;
+  class capability { fowner sys_resource fsetid sys_ptrace };
+  class capability2 block_suspend;
+  class dir { setattr read create write rmdir remove_name add_name };
+  class file { rename setattr read create ioctl write getattr unlink open append };
+  class lnk_file { read getattr };
+  class udp_socket name_bind;
+  attribute port_type;
+  class tcp_socket name_connect;
+}
+
+#============= httpd_t ==============
+allow httpd_t puppet_etc_t:dir read;
+allow httpd_t puppet_etc_t:file { read getattr open ioctl };
+allow httpd_t puppet_etc_t:lnk_file { read getattr };
+allow httpd_t puppet_log_t:dir { write add_name };
+allow httpd_t puppet_log_t:file { write create open };
+allow httpd_t puppet_var_lib_t:dir { write rmdir setattr read remove_name create add_name };
+allow httpd_t puppet_var_lib_t:file { rename write setattr create unlink append };
+allow httpd_t self:capability sys_ptrace;
+allow httpd_t self:capability { fowner sys_resource fsetid };
+allow httpd_t self:capability2 block_suspend;
+allow httpd_t puppet_port_t:udp_socket name_bind;

--- a/site/site_selinux/manifests/drupal.pp
+++ b/site/site_selinux/manifests/drupal.pp
@@ -1,0 +1,67 @@
+# Class site_selinux::drupal
+#
+# Selinux contexts for Drupal sites.
+class site_selinux::drupal {
+
+ # Allow DB connections.
+  selboolean { 'httpd_can_network_connect_db':
+    persistent => true,
+    value      => on,
+  }
+
+  # Allow use of sendmail.
+  selboolean { 'httpd_can_sendmail':
+    persistent => true,
+    value      => on,
+  }
+
+  # Allow memcache connections.
+  selboolean { 'httpd_can_network_memcache':
+    persistent => true,
+    value      => on,
+  }
+
+  # Set default file contexts for httpd-writable Drupal directories (files/private_files).
+  $drupal_file_paths = hiera_hash('site_selinux::drupal::drupal_file_paths', {})
+  create_resources('selinux::fcontext', $drupal_file_paths, { context => 'httpd_sys_rw_content_t' })
+
+  # Set default file contexts for httpd-readable paths
+  # (static files outside of webroot that apache may need to read).
+  $httpd_readable_paths = hiera_hash('site_selinux::drupal::httpd_readable_paths', {})
+  create_resources('selinux::fcontext', $httpd_readable_paths, { context => 'httpd_sys_content_t' })
+
+  # Custom httpdsolr selinux module:
+  # allow php/httpd/varnishd to access solr network ports.
+  selinux::module { 'httpdsolr':
+    source => 'puppet:///modules/site_selinux/httpdsolr/httpdsolr.te',
+  }
+
+  # Custom httpdvarnish selinux module: allow php/httpd to access varnish control ports.
+  selinux::module { 'httpdvarnish':
+    source => 'puppet:///modules/site_selinux/httpdvarnish/httpdvarnish.te',
+  }
+
+  # Use semanage to assign solr ports to the solr_port_t type
+  # which is defined in the httpdsolr selinux module.
+  #
+  # Assign port tcp/8112 to solr (used for solr 1.x)
+  exec { 'semanage-port-8112':
+    command => '/usr/sbin/semanage port -a -t solr_port_t -p tcp 8112',
+    unless  => '/bin/grep solr_port_t /etc/selinux/targeted/modules/active/ports.local | /bin/grep -q 8112',
+    require => Selinux::Module['httpdsolr'],
+  }
+
+  # Assign port tcp/8114 to solr (used for solr 4.x).
+  exec { 'semanage-port-8114':
+    command => '/usr/sbin/semanage port -a -t solr_port_t -p tcp 8114',
+    unless  => '/bin/grep solr_port_t /etc/selinux/targeted/modules/active/ports.local | /bin/grep -q 8114',
+    require => Selinux::Module['httpdsolr'],
+  }
+
+  # Assign port tcp/8115 to solr (used for solr 5.x).
+  exec { 'semanage-port-8115':
+    command => '/usr/sbin/semanage port -a -t solr_port_t -p tcp 8115',
+    unless  => '/bin/grep solr_port_t /etc/selinux/targeted/modules/active/ports.local | /bin/grep -q 8115',
+    require => Selinux::Module['httpdsolr'],
+  }
+}

--- a/site/site_selinux/manifests/init.pp
+++ b/site/site_selinux/manifests/init.pp
@@ -1,0 +1,9 @@
+# Class site_selinux
+#
+# Common SELinux configuration for all hosts.
+
+class site_selinux {
+  # Pull in selinux class to install selinux packages and enable selinux.
+  require selinux
+
+}

--- a/site/site_selinux/manifests/newrelic.pp
+++ b/site/site_selinux/manifests/newrelic.pp
@@ -1,0 +1,11 @@
+# Class site_selinux::newrelic
+#
+# Selinux contexts for web servers running newrelic.
+class site_selinux::newrelic {
+
+  # Custom newrelic selinux module: allow newrelic to block_suspend and write out newrelic logs.
+  selinux::module { 'newrelic':
+    source => 'puppet:///modules/site_selinux/newrelic/newrelic.te',
+  }
+
+}

--- a/site/site_selinux/manifests/php-systemd.pp
+++ b/site/site_selinux/manifests/php-systemd.pp
@@ -1,0 +1,17 @@
+# Class site_selinux::php-systemd
+#
+# Selinux contexts for web servers running php-fpm via systemd.
+class site_selinux::php-systemd {
+
+  # Custom php-systemd selinux module: allow php-systemd to do its socket magic.
+  selinux::module { 'php-systemd':
+    source => 'puppet:///modules/site_selinux/php-systemd/php-systemd.te',
+  }
+
+  # Use semanage to assign ports tcp/9000-9010 to php-fpm.
+  exec { 'semanage-port-9000-9010':
+    command => '/usr/sbin/semanage port -a -t php_port_t -p tcp 9000-9010',
+    unless  => '/bin/grep php_port_t /etc/selinux/targeted/modules/active/ports.local | /bin/grep -q 9010',
+    require => Selinux::Module['php-systemd'],
+  }
+}

--- a/site/site_selinux/manifests/puppetmaster.pp
+++ b/site/site_selinux/manifests/puppetmaster.pp
@@ -1,0 +1,16 @@
+# Class site_selinux::puppetmaster
+#
+# Selinux contexts for a Puppet master server running under apache+passenger.
+class site_selinux::puppetmaster {
+
+  # Custom puppetmaster selinux module: allow passenger/httpd to access puppet.
+  selinux::module { 'puppetmaster':
+    source => 'puppet:///modules/site_selinux/puppetmaster/puppetmaster.te',
+  }
+
+  # Set default file contexts for local git clones used by puppet
+  # e.g. infra_private and hiera_private which aren't stored directly in /etc/puppet
+  $puppet_etc_t_file_paths = hiera_hash('site_selinux::puppetmaster::puppet_etc_t_file_paths', {})
+  create_resources('selinux::fcontext', $puppet_etc_t_file_paths, { context => 'puppet_etc_t' })
+
+}


### PR DESCRIPTION
This pulls in a number of SELinux classes and custom SELinux modules.  Enables SELinux by default, and enables Drupal-related SELinux setup on web servers.
