### PR TITLE
Add configuration for web writable directories and selinux contexts

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -4,7 +4,7 @@ forge 'forge.puppetlabs.com'
 # Install modules from the Forge
 mod 'arioch/redis', '1.2.3'
 mod 'crayfishx/firewalld', '2.2.0'
-mod 'jfryman/selinux', '0.4.0'
+mod 'puppet/selinux', '0.5.0'
 mod 'puppetlabs/apache', '1.10.0'
 mod 'puppetlabs/concat', '2.2.0'
 mod 'puppetlabs/denyhosts', '0.1.0'

--- a/hiera/hosts/vagrant-multi1.tag1consulting.com.yaml
+++ b/hiera/hosts/vagrant-multi1.tag1consulting.com.yaml
@@ -27,6 +27,11 @@ site_profile::web::vhosts:
           - FollowSymLinks
           - MultiViews
 
+# Create web-writable directories.
+site_profile::web::apache_writable_dirs:
+  - '/var/www/drupal_private_files'
+  - '/var/www/drupal_public_files'
+
 #################################################
 # MySQL configuration.
 #
@@ -56,6 +61,14 @@ mysql::server::grants:
 # SELinux configuration.
 # Uncomment this to disable SELinux on the Dev VM.
 #selinux::mode: 'disabled'
+
+site_selinux::drupal::drupal_file_paths:
+  'localdev-private-files':
+    pathname: '/var/www/drupal_private_files(/.*)?'
+    restorecond_path: '/var/www/drupal_private_files'
+  'localdev-public-files':
+    pathname: '/var/www/drupal_public_files(/.*)?'
+    restorecond_path: '/var/www/drupal_public_files'
 
 #################################################
 # PHP configuration.

--- a/site/site_profile/manifests/web.pp
+++ b/site/site_profile/manifests/web.pp
@@ -18,6 +18,18 @@ class site_profile::web {
   $vhosts = hiera_hash('site_profile::web::vhosts', {})
   create_resources('apache::vhost', $vhosts, { require => File[$vhost_dir], })
 
+  # Create additional directories which need to be writable by apache/php.
+  # Note these same directories should also be included in
+  # site_selinux::drupal::drupal_file_paths to ensure they have correct selinux contexts.
+  $web_writable_dirs = hiera_array('site_profile::web::apache_writable_dirs', [])
+  file { $web_writable_dirs:
+    ensure  => directory,
+    owner   => 'apache',
+    group   => 'apache',
+    mode    => 0755,
+    require => Package['httpd'],
+  }
+
   # PHP
   # Setup php.ini.
   $php_ini = hiera_hash('site_profile::web::php_ini')


### PR DESCRIPTION
Adds an example of Drupal public/private writable directories.

Also updates the selinux module to the new owner (puppet / voxpupuli) now that it's been handed off by jfryman.