### PR TITLE
Ensure PHP is installed before Drush so we get the right php version

### DIFF
--- a/code/environments/production/site/site_profile/manifests/web.pp
+++ b/code/environments/production/site/site_profile/manifests/web.pp
@@ -134,7 +134,7 @@ class site_profile::web {
 
   package { 'drush':
     ensure  => latest,
-    require => Class['yumrepos::drush8'],
+    require => [ Class['yumrepos::drush8'], Class['php::cli'], ],
   }
 
   # Setup memcached.


### PR DESCRIPTION
Otherwise yum install of drush may pull in a newer PHP version than desired.