### PR TITLE
Bump firewalld module version

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -3,7 +3,7 @@ forge 'forge.puppetlabs.com'
 
 # Install modules from the Forge
 mod 'arioch/redis', '1.2.4'
-mod 'crayfishx/firewalld', '3.1.8'
+mod 'crayfishx/firewalld', '3.3.1'
 mod 'puppet/selinux', '0.8.0'
 mod 'puppet/staging', '2.2.0'
 mod 'puppetlabs/apache', '1.11.0'


### PR DESCRIPTION
Fixes initial provision error:

```
==> default: Error: /Stage[main]/Site_profile::Web/Firewalld_rich_rule[Allow http from all]: Could not evaluate: Execution of '/bin/firewall-offline-cmd --zone public --query-rich-rule rule family="ipv4" service name="http" accept' returned 1: no
==> default: Error: /Stage[main]/Site_profile::Web/Firewalld_rich_rule[Allow https from all]: Could not evaluate: Execution of '/bin/firewall-offline-cmd --zone public --query-rich-rule rule family="ipv4" service name="https" accept' returned 1: no
==> default: Error: /Stage[main]/Site_profile::Base/Firewalld_rich_rule[Accept SSH from any]: Could not evaluate: Execution of '/bin/firewall-offline-cmd --zone public --query-rich-rule rule family="ipv4" service name="ssh" accept' returned 1: no
```